### PR TITLE
add list-style-type to .substep::before

### DIFF
--- a/styles/simple-styles/task_steps.css
+++ b/styles/simple-styles/task_steps.css
@@ -32,7 +32,7 @@
     padding: 0px; 
     margin-left: 30px;}
 .sublist .substep::before{
-    content: counter(my-counter); 
+    content: counter(my-counter, lower-roman); 
     position: absolute; 
     left: 55px; 
     border: 1px solid #aaa; 


### PR DESCRIPTION
parallels a change made for topic editor to have substeps use letters instead of numbers.